### PR TITLE
Remove ISEP designation from project

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and create a local branch for development.
 
     git checkout -b <branch-name>
 
-Please follow the convention isep-challenge-group-&lt;*group-number*&gt; when naming your branch.
+Please follow the convention call-center-challenge-group-&lt;*group-number*&gt; when naming your branch.
 
 ## Create a Twilio Account
 You'll use [Twilio](https://www.twilio.com/) as communication provider, so you need to setup an account in order

--- a/src/test/postman/challenge.postman.collection.json
+++ b/src/test/postman/challenge.postman.collection.json
@@ -1,7 +1,7 @@
 {
 	"variables": [],
 	"info": {
-		"name": "ISEP Challenge",
+		"name": "Challenge",
 		"_postman_id": "9652b89d-be95-21ed-5b03-dbd73b9e81c6",
 		"description": "",
 		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"


### PR DESCRIPTION
This PR removes the `isep` references from the project, enabling the use of this project skeleton for other events.